### PR TITLE
Fix Build Process

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,11 +161,11 @@
     "iconv-lite": "^0.4.19"
   },
   "devDependencies": {
+    "@types/iconv-lite": "^0.0.1",
     "@types/mocha": "^2.2.44",
     "@types/node": "^6.0.90",
-    "@types/iconv-lite": "^0.0.1",
     "tslint": "^5.8.0",
-    "typescript": "^2.6.1",
+    "typescript": "^3.9.10",
     "vscode": "^1.1.6"
   }
 }


### PR DESCRIPTION
One of your dependencies (`@types/node@^6.0.90`) contains a `/// <reference lib="..." />` reference which - according to [TypeScript's Documentation](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-0.html) requires at least TypeScript v3. This causes npm to fail building and packaging your extension currently.

Changes made in this PR will update the `typescript` package to v3 (most recent version is `4.6.x`) which will make the build process work again.