### PR TITLE
Set default composer executable path to 'composer'

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,11 +75,8 @@
         },
         "composer.executablePath": {
           "scope": "resource",
-          "type": [
-            "string",
-            "null"
-          ],
-          "default": null,
+          "type": "string",
+          "default": "",
           "description": "Path to the composer executable."
         },
         "composer.ignorePlatformReqs": {

--- a/src/composer/extension.ts
+++ b/src/composer/extension.ts
@@ -451,13 +451,6 @@ export class ComposerExtension extends Disposable {
 
 	protected runCommand(args: string[], context: ComposerContext, ensureComposerProject: boolean = true): void {
 
-		// Ensure that composer executable path is set.
-		if (!context.settings.executablePath) {
-			throw new ComposerError({
-				message: Strings.ComposerExecutablePathRequired
-			});
-		}
-
 		// Ensure the command is run against a composer project
 		if (ensureComposerProject && !context.isComposerProject()) {
 			window.showInformationMessage(Strings.ComposerProjectRequired);

--- a/src/composer/settings.ts
+++ b/src/composer/settings.ts
@@ -29,7 +29,7 @@ export class ComposerSettings {
 	}
 
 	public get executablePath(): string {
-		return this.config.get<string>(SettingNames.ExecutablePath, undefined);
+		return this.config.get<string>(SettingNames.ExecutablePath) || 'composer';
 	}
 
 	public get ignorePlatformReqs(): boolean {

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -55,7 +55,6 @@ export class Strings {
 	static WorkspaceFolderPick = 'Select workspace folder to run composer command ...';
 
 	// Errors
-	static ComposerExecutablePathRequired = 'Please set composer.executablePath in your user settings in order to to access composer features.';
 	static ComposerNotFound = 'Composer could not be found in the system.';
 	static ComposerContextRequired = 'Please open a workspace folder in order to access composer features.';
 	static ComposerProjectRequired = 'Open a folder with a composer project in order to access composer features.';


### PR DESCRIPTION
This PR defines a default value (`composer`) for the `composer.executablePath` setting. 
It works on setups where `composer` is available globally (through the `PATH` environment variable).


Should fix #12 (at least the [first message](https://github.com/ikappas/vscode-composer/issues/12#issue-490833826) from @Baneeishaque).


Please note that the README still needs to be updated to reflect this change.
